### PR TITLE
Create optimized thumb parameter

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -8,7 +8,7 @@ require 'new_relic/rack/agent_hooks'
 require 'new_relic/rack/error_collector'
 
 Honeybadger.configure do |config|
-  #config.api_key = 'c6971908'
+  config.api_key = 'c6971908'
 end
 use Honeybadger::Rack
 use NewRelic::Rack::AgentHooks


### PR DESCRIPTION
This adds an optimized_thumb parameter that can be used as a replacement for thumb and uses https://github.com/toy/image_optim
